### PR TITLE
Fix DirectoryBrowserGrid typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aserto/aserto-react-components",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Aserto React components",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/UserCard/index.tsx
+++ b/src/components/UserCard/index.tsx
@@ -3,13 +3,7 @@ import styled, { css } from 'styled-components'
 import { theme } from '../../theme'
 import usericon from './user.svg'
 import { mapTestIdToProps } from '../../utils'
-
-interface User {
-  display_name: string
-  email: string
-  id: string
-  picture: string
-}
+import { User } from '../../types'
 
 export type UserCardProps = {
   user: User

--- a/src/stories/EvaluateDisplayState.stories.tsx
+++ b/src/stories/EvaluateDisplayState.stories.tsx
@@ -7,7 +7,9 @@ export default {
   component: EvaluateDisplayState,
 } as Meta
 
-const Template: Story = (args) => <EvaluateDisplayState {...args} />
+const Template: Story = (args: React.ComponentProps<typeof EvaluateDisplayState>) => (
+  <EvaluateDisplayState {...args} />
+)
 
 export const WithVisibleAndDisabled = Template.bind({})
 WithVisibleAndDisabled.args = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,30 +1,6 @@
-export type UserAttr = {
-  department: string
-  manager: string
-  title: string
-}
-
-export interface UserRoles {
-  [x: string]: Array<string>
-}
-
-export interface Identities {
-  [x: string]: string
-}
-export interface Scopes {
-  [x: string]: string
-}
-
 export type User = {
   id: string
-  attr: UserAttr
-  created_at: string
-  updated_at: string
   display_name: string
-  enabled: boolean
   email: string
   picture: string
-  roles: UserRoles
-  identities: Identities
-  scopes: Scopes
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "jsx": "react",
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "noEmit": true
   },
   "include": ["src/**/*", "src/custom.d.ts"],
   "exclude": [


### PR DESCRIPTION
The `User` type required by `DirectoryBrowserGrid` requires many more properties than it needs. They seem to be based on the response from the users API based on how we use it in the Console, but the types are out of date and could lead to breakage in the future.