### PR TITLE
Make component Array props more permissive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aserto/aserto-react-components",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "Aserto React components",
   "main": "dist/index.js",
   "scripts": {
@@ -53,6 +53,7 @@
     "@storybook/addon-essentials": "^6.1.21",
     "@storybook/addon-links": "^6.1.21",
     "@storybook/react": "^6.1.21",
+    "@types/react-table": "^7.7.4",
     "@types/styled-components": "^5.1.7",
     "@typescript-eslint/eslint-plugin": "^4.16.1",
     "@typescript-eslint/parser": "^4.16.1",

--- a/src/components/DirectoryBrowserGrid/index.tsx
+++ b/src/components/DirectoryBrowserGrid/index.tsx
@@ -46,7 +46,7 @@ const EmptyUsersContainer = styled.div`
   }
 `
 
-const renderUserCards = (users: Array<User>, onClick: (id: string) => void) => {
+const renderUserCards = (users: readonly User[], onClick: (id: string) => void) => {
   if (users.length === 0) {
     return (
       <EmptyUsersContainer>
@@ -60,7 +60,7 @@ const renderUserCards = (users: Array<User>, onClick: (id: string) => void) => {
   ))
 }
 
-const filterUsers = (users: Array<User>, filter: string): Array<User> => {
+const filterUsers = (users: readonly User[], filter: string): readonly User[] => {
   if (filter) {
     return users.filter(
       (value) =>
@@ -77,7 +77,7 @@ export const scrollToTop = () => {
 
 export type DirectoryBrowserGridProps = {
   pageSize: number
-  users: Array<User>
+  users: readonly User[]
   filter: string
   onClickCard: (id: string) => void
 }

--- a/src/components/EvaluateDisplayState/index.tsx
+++ b/src/components/EvaluateDisplayState/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 
-export type DisplayState = {
+export type DisplayState = Readonly<{
   [key: string]: string | boolean
-}
+}>
 
 const EvaluateDisplayStateComponent = ({
   children,

--- a/src/components/Highlight/index.tsx
+++ b/src/components/Highlight/index.tsx
@@ -157,7 +157,7 @@ const Code = styled.div`
 `
 interface Props {
   children: React.ReactElement | string | unknown
-  style?: unknown
+  style?: React.CSSProperties
 }
 export const Highlight: React.FC<Props> = ({ children, style }) => {
   useLayoutEffect(() => {

--- a/src/components/IdentityContext/index.tsx
+++ b/src/components/IdentityContext/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Input, Select } from '../..'
-// import { Input, Select } from '@aserto/aserto-react-components'
 
 const Col = styled.div`
   width: 100%;

--- a/src/components/PolicyCard/index.tsx
+++ b/src/components/PolicyCard/index.tsx
@@ -19,7 +19,7 @@ export type PolicyCardProps = {
   testId?: string
   disabled?: boolean
   policyIconVariant?: 'pending' | 'error' | 'loaded'
-  errors?: Array<string>
+  errors?: readonly string[]
 }
 
 const Icon = styled.img`

--- a/src/components/RadioButtonGroup/index.tsx
+++ b/src/components/RadioButtonGroup/index.tsx
@@ -72,7 +72,7 @@ interface Option {
 }
 
 export type RadioButtonGroupProps = {
-  options: Array<Option>
+  options: readonly Option[]
   onChange: (val: string) => void
   defaultSelected?: string
   label?: string

--- a/src/components/RequestEditor/index.tsx
+++ b/src/components/RequestEditor/index.tsx
@@ -84,8 +84,8 @@ const HighlightWrapper = styled.div`
 
 export const RequestEditor = ({ identity, setIdentity, onExecute, output }) => {
   const [mode, setMode] = useState(identity ? 'MANUAL' : 'ANONYMOUS')
-  const [input, setInput] = useState()
-  const [query, setQuery] = useState()
+  const [input, setInput] = useState<string>()
+  const [query, setQuery] = useState<string>()
 
   const requestOptions = [
     {

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -11,7 +11,7 @@ export type SelectOption = {
 }
 
 export type SelectProps = {
-  options: Array<SelectOption>
+  options: readonly SelectOption[]
   defaultValue?: SelectOption
   onChange: (e: any) => void
   disabled?: boolean

--- a/src/components/SelectWithDots/index.tsx
+++ b/src/components/SelectWithDots/index.tsx
@@ -21,7 +21,7 @@ export type SelectOption = {
 }
 
 export type SelectWithDotsProps = {
-  options: Array<SelectOption>
+  options: readonly SelectOption[]
   defaultValue?: SelectOption
   onChange: (e: any) => void
   disabled?: boolean

--- a/src/components/SelectWithoutControl/index.tsx
+++ b/src/components/SelectWithoutControl/index.tsx
@@ -21,7 +21,7 @@ export type SelectOption = {
 }
 
 export type SelectWithoutControlProps = {
-  options: Array<SelectOption>
+  options: readonly SelectOption[]
   defaultValue?: SelectOption
   onChange: (e: any) => void
   disabled?: boolean

--- a/src/components/SwitchButton/index.tsx
+++ b/src/components/SwitchButton/index.tsx
@@ -52,7 +52,8 @@ const SwitchHandle = styled.div<{ $isChecked?: boolean }>`
   background-color: #4a4a4a;
 `
 
-export type SwitchButtonProps = {
+export interface SwitchButtonProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof SwitchLabel>, 'onChange'> {
   className?: string
   checked: boolean
   onChange: (checked: boolean) => void
@@ -61,7 +62,6 @@ export type SwitchButtonProps = {
   handleColor?: string
   focusShadow?: string
   disabled?: boolean
-  [props: string]: any
   testId?: string
 }
 

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { FormControl } from 'react-bootstrap'
+import { FormControl, FormControlProps } from 'react-bootstrap'
 import './TextArea.css'
 
 export type TextAreaProps = {
   value: string | number
-  onChange: (e: any) => void
+  onChange: FormControlProps['onChange']
   rows?: number
   placeholder?: string
   style?: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -3187,6 +3187,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-table@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@types/react-table/-/react-table-7.7.4.tgz#7d01b3a9516e8dcb7152858271210ef08c6cc32a"
+  integrity sha512-CIBJJx9iid8k+kN1/WD8vSXnM1Qc6zX3ihrMnt3ilZxLSrFJSw4wc1u9WeT4dWjbECEO1wJBGVHfSknR4nzFiQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.0.tgz#882839db465df1320e4753e6e9f70ca7e9b4d46d"


### PR DESCRIPTION
This PR goes through every array prop and changes it to a readonly array. This means that callers are now allowed to pass in readonly arrays. Before they could not because `Array` requires values to be mutable, i.e. support `push`, `pop`, etc. We should never require array props to be mutable unless the component actually plans to mutate them (which is usually not a good design anyway).

https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes
> function sum(nums: number[]): number: Use ReadonlyArray if a function does not write to its parameters.
