### PR TITLE
Add border to SelectWithDots menu and fix group padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aserto/aserto-react-components",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Aserto React components",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react'
-import ReactSelect, { components, NamedProps } from 'react-select'
+import ReactSelect, { components, NamedProps, StylesConfig } from 'react-select'
 import { theme } from '../../theme'
 import { Label } from '../Label'
 
@@ -15,11 +15,7 @@ export type ReactSelectElement = ReactSelect<SelectOption>
 export interface SelectProps
   extends Omit<
     NamedProps<SelectOption>,
-    | 'isDisabled'
-    | 'inputId'
-    | 'styles'
-    | 'formatGroupId'
-    | 'components'
+    'isDisabled' | 'inputId' | 'styles' | 'formatGroupId' | 'components'
   > {
   options: readonly SelectOption[]
   defaultValue?: SelectOption
@@ -30,11 +26,8 @@ export interface SelectProps
   disableLabel?: boolean
 }
 
-const groupStyles = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  padding: 0,
+const groupLabelStyle = {
+  position: 'relative' as const,
   marginTop: -8,
   marginBottom: -3,
   marginLeft: -11,
@@ -43,7 +36,7 @@ const groupStyles = {
   backgroundColor: theme.grey,
 }
 
-const formatGroupLabel = () => <div style={groupStyles} />
+const formatGroupLabel = () => <div style={groupLabelStyle} />
 
 export const Select: React.ForwardRefExoticComponent<
   SelectProps & React.RefAttributes<ReactSelectElement>
@@ -74,7 +67,7 @@ export const Select: React.ForwardRefExoticComponent<
       )
     }, [])
 
-    const colourStyles = {
+    const colourStyles: StylesConfig<SelectOption, false> = {
       control: (styles, { isDisabled, isFocused }) => {
         return {
           ...styles,
@@ -112,6 +105,12 @@ export const Select: React.ForwardRefExoticComponent<
             ...styles[':active'],
             backgroundColor: theme.grey40,
           },
+        }
+      },
+      group: (styles) => {
+        return {
+          ...styles,
+          paddingBottom: 0,
         }
       },
       input: (styles) => {

--- a/src/components/SelectWithDots/index.tsx
+++ b/src/components/SelectWithDots/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import ReactSelect, { components, NamedProps } from 'react-select'
+import ReactSelect, { components, NamedProps, StylesConfig } from 'react-select'
 import { theme } from '../../theme'
 import { Label } from '../Label'
 import { Button } from '../Button'
@@ -51,11 +51,8 @@ export interface SelectWithDotsProps
   menuAlignment?: MenuAlignment
 }
 
-const groupStyles = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  padding: 0,
+const groupLabelStyle = {
+  position: 'relative' as const,
   marginTop: -8,
   marginBottom: -3,
   marginLeft: -11,
@@ -64,7 +61,7 @@ const groupStyles = {
   backgroundColor: theme.grey,
 }
 
-const formatGroupLabel = () => <div style={groupStyles} />
+const formatGroupLabel = () => <div style={groupLabelStyle} />
 
 export const SelectWithDots: React.ForwardRefExoticComponent<
   SelectWithDotsProps & React.RefAttributes<ReactSelectElement>
@@ -81,6 +78,7 @@ export const SelectWithDots: React.ForwardRefExoticComponent<
       shouldDisabledOptions,
       onBlur,
       menuAlignment = 'bottom-right',
+      menuPortalTarget,
       ...props
     },
     ref
@@ -124,25 +122,30 @@ export const SelectWithDots: React.ForwardRefExoticComponent<
       ({ innerRef, innerProps, children }) => {
         const alignmentStyleOverrides: Record<MenuAlignment, React.CSSProperties> = {
           'bottom-left': {
-            top: 35,
+            top: 39,
             left: 0,
           },
           'bottom-right': {
-            top: 35,
+            top: 39,
             right: 0,
           },
           'right-bottom': {
             bottom: 0,
             left: 40,
-            marginBottom: -2,
+            marginBottom: 1,
             marginLeft: 2,
           },
           'right-top': {
             top: 0,
             left: 40,
-            marginTop: -3,
+            marginTop: 1,
             marginLeft: 2,
           },
+        }
+
+        const alignmentStyleOverride = alignmentStyleOverrides[menuAlignment]
+        if (menuPortalTarget != null && 'top' in alignmentStyleOverride) {
+          alignmentStyleOverride.top = Number(alignmentStyleOverride.top) - 38
         }
 
         return (
@@ -152,7 +155,7 @@ export const SelectWithDots: React.ForwardRefExoticComponent<
               zIndex: 20,
               position: 'absolute',
               width: 250,
-              ...alignmentStyleOverrides[menuAlignment],
+              ...alignmentStyleOverride,
             }}
             {...innerProps}
           >
@@ -194,7 +197,7 @@ export const SelectWithDots: React.ForwardRefExoticComponent<
       )
     }, [])
 
-    const colourStyles = {
+    const colourStyles: StylesConfig<SelectOption, false> = {
       control: (styles, { isDisabled, isFocused }) => {
         return {
           ...styles,
@@ -272,7 +275,8 @@ export const SelectWithDots: React.ForwardRefExoticComponent<
       menuList: (style) => ({
         ...style,
         zIndex: 5,
-        borderRadius: 6,
+        padding: 0,
+        border: `1px solid ${theme.grey50}`,
       }),
       indicatorSeparator: (styles) => ({
         ...styles,
@@ -314,6 +318,7 @@ export const SelectWithDots: React.ForwardRefExoticComponent<
             onChange(option)
           }}
           menuIsOpen={open}
+          menuPortalTarget={menuPortalTarget}
           styles={colourStyles}
           formatGroupLabel={formatGroupLabel}
           components={{ ValueContainer, Option, Menu: CustomMenu }}

--- a/src/components/SelectWithoutControl/index.tsx
+++ b/src/components/SelectWithoutControl/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import ReactSelect, { components, NamedProps } from 'react-select'
+import ReactSelect, { components, NamedProps, StylesConfig } from 'react-select'
 import { theme } from '../../theme'
 import { Label } from '../Label'
 import { Button } from '../Button'
@@ -53,11 +53,8 @@ export interface SelectWithoutControlProps
   onBlur?: (firstSelectedOption?: SelectOption) => void
 }
 
-const groupStyles = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  padding: 0,
+const groupLabelStyle = {
+  position: 'relative' as const,
   marginTop: -8,
   marginBottom: -3,
   marginLeft: -11,
@@ -66,7 +63,7 @@ const groupStyles = {
   backgroundColor: theme.grey,
 }
 
-const formatGroupLabel = () => <div style={groupStyles} />
+const formatGroupLabel = () => <div style={groupLabelStyle} />
 
 const menuHeaderStyle = {
   padding: '4px 12px',
@@ -205,7 +202,7 @@ export const SelectWithoutControl: React.ForwardRefExoticComponent<
       )
     }, [])
 
-    const colourStyles = {
+    const colourStyles: StylesConfig<SelectOption, false> = {
       control: (styles, { isDisabled, isFocused }) => {
         return {
           ...styles,
@@ -243,6 +240,12 @@ export const SelectWithoutControl: React.ForwardRefExoticComponent<
             ...styles[':active'],
             backgroundColor: theme.grey30,
           },
+        }
+      },
+      group: (styles) => {
+        return {
+          ...styles,
+          paddingBottom: 0,
         }
       },
       input: (styles) => {

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -29,12 +29,22 @@ const groupedOptions = [
   {
     options: [
       {
-        label: "I'm another group!",
-        value: 'x',
-        shouldStopPropagation: true,
-        onClick: () => console.log('clicked'),
+        label: "I'm a group!",
+        value: 'group',
       },
     ],
+  },
+  {
+    options: [
+      {
+        label: "I'm another group!",
+        value: 'another_group',
+      },
+    ],
+  },
+  {
+    label: 'Ungrouped option',
+    value: 'ungrouped',
   },
 ]
 

--- a/src/stories/SelectWithDots.stories.tsx
+++ b/src/stories/SelectWithDots.stories.tsx
@@ -7,9 +7,7 @@ export default {
   component: SelectWithDots,
 } as Meta
 
-const Template: Story<SelectWithDotsProps> = (args) => (
-  <SelectWithDots {...args} />
-)
+const Template: Story<SelectWithDotsProps> = (args) => <SelectWithDots {...args} />
 
 const identityOptions = [
   {
@@ -38,7 +36,6 @@ const groupedOptions = [
     value: 'EDIT',
   },
   {
-    //@ts-ignore
     options: [
       {
         label: 'Disconnect',
@@ -49,7 +46,6 @@ const groupedOptions = [
     ],
   },
   {
-    //@ts-ignore
     options: [
       {
         label: 'Remove',


### PR DESCRIPTION
- Adds a border around SelectWithDots menu:
<img width="272" src="https://user-images.githubusercontent.com/88290408/136303913-122403c1-9097-47a6-81b1-bffd3bcaad97.png">
- Fixes issues in all Select components with padding when there are multiple groups:
<img width="372" src="https://user-images.githubusercontent.com/88290408/136303861-16c60d3e-0717-49c7-8d68-7ee2d62f2f3a.png">

