### PR TITLE
Allow SelectWithDots components to be overridden and upgrade react-select

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aserto/aserto-react-components",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "description": "Aserto React components",
   "main": "dist/index.js",
   "scripts": {
@@ -31,6 +31,7 @@
     "react": "^16.14.0",
     "react-bootstrap": "^1.4.3",
     "react-dom": "^16.14.0",
+    "react-select": "^5.1.0",
     "styled-components": "^5.3.0"
   },
   "devDependencies": {
@@ -71,6 +72,7 @@
     "react": "^17.0.1",
     "react-bootstrap": "^1.4.3",
     "react-dom": "^17.0.1",
+    "react-select": "^5.1.0",
     "regenerator-runtime": "^0.13.7",
     "rollup": "^2.40.0",
     "rollup-plugin-css-porter": "^1.0.2",
@@ -86,12 +88,10 @@
   },
   "dependencies": {
     "@atlaskit/tooltip": "^17.2.0",
-    "@types/react-select": "^4.0.18",
     "@types/react-table": "^7.7.4",
     "postcss": "^8.2.7",
     "react-infinite-scroll-component": "^6.1.0",
     "react-router-dom": "^5.2.0",
-    "react-select": "^4.0.2",
     "react-table": "^7.7.0"
   },
   "prettier": "@aserto/ts-linting-configs/prettier.config"

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,5 +1,11 @@
 import React, { useCallback } from 'react'
-import ReactSelect, { components, NamedProps, StylesConfig } from 'react-select'
+import ReactSelect, {
+  components,
+  OptionProps,
+  Props,
+  SelectInstance,
+  StylesConfig,
+} from 'react-select'
 import { theme } from '../../theme'
 import { Label } from '../Label'
 
@@ -10,11 +16,11 @@ export type SelectOption = {
   onClick?: () => void
 }
 
-export type ReactSelectElement = ReactSelect<SelectOption>
+export type ReactSelectElement = SelectInstance<SelectOption>
 
 export interface SelectProps
   extends Omit<
-    NamedProps<SelectOption>,
+    Props<SelectOption, false>,
     'isDisabled' | 'inputId' | 'styles' | 'formatGroupId' | 'components'
   > {
   options: readonly SelectOption[]
@@ -48,7 +54,7 @@ export const Select: React.ForwardRefExoticComponent<
       boxShadow: 'none',
     }
 
-    const Option = useCallback((props) => {
+    const Option = useCallback((props: OptionProps<SelectOption, false>) => {
       return (
         <div>
           <components.Option

--- a/src/components/SelectWithDots/index.tsx
+++ b/src/components/SelectWithDots/index.tsx
@@ -1,5 +1,12 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import ReactSelect, { components, NamedProps, StylesConfig } from 'react-select'
+import ReactSelect, {
+  components,
+  MenuProps,
+  OptionProps,
+  Props,
+  SelectInstance,
+  StylesConfig,
+} from 'react-select'
 import { theme } from '../../theme'
 import { Label } from '../Label'
 import { Button } from '../Button'
@@ -22,11 +29,11 @@ export type SelectOption = {
   isDisabled?: boolean
 }
 
-export type ReactSelectElement = ReactSelect<SelectOption>
+export type ReactSelectElement = SelectInstance<SelectOption>
 
 export interface SelectWithDotsProps
   extends Omit<
-    NamedProps<SelectOption>,
+    Props<SelectOption, false>,
     | 'onFocus'
     | 'onBlur'
     | 'isDisabled'
@@ -37,7 +44,6 @@ export interface SelectWithDotsProps
     | 'inputId'
     | 'styles'
     | 'formatGroupId'
-    | 'components'
     | 'value'
   > {
   defaultValue?: SelectOption
@@ -46,7 +52,7 @@ export interface SelectWithDotsProps
   label?: string
   style?: React.CSSProperties
   disableLabel?: boolean
-  shouldDisabledOptions?: boolean
+  shouldDisableOptions?: boolean
   onBlur?: (firstSelectedOption?: SelectOption) => void
   menuAlignment?: MenuAlignment
 }
@@ -75,9 +81,10 @@ export const SelectWithDots: React.ForwardRefExoticComponent<
       style,
       disableLabel,
       name,
-      shouldDisabledOptions,
+      shouldDisableOptions,
       onBlur,
       menuAlignment = 'bottom-right',
+      components: componentsProp,
       menuPortalTarget,
       ...props
     },
@@ -119,7 +126,7 @@ export const SelectWithDots: React.ForwardRefExoticComponent<
     }, [open, selectRef])
 
     const CustomMenu = useCallback(
-      ({ innerRef, innerProps, children }) => {
+      ({ innerRef, innerProps, children }: MenuProps<SelectOption, false>) => {
         const alignmentStyleOverrides: Record<MenuAlignment, React.CSSProperties> = {
           'bottom-left': {
             top: 39,
@@ -163,39 +170,41 @@ export const SelectWithDots: React.ForwardRefExoticComponent<
           </div>
         )
       },
-      [menuAlignment]
+      [menuAlignment, selectRef]
     )
 
-    const ValueContainer = useCallback(({ children, ...rest }) => {
+    const ValueContainer = useCallback(({ children }) => {
       return (
-        <DotsButton {...rest} variant="secondary-borderless">
+        <DotsButton variant="secondary-borderless">
           <img src={dots} alt="see-more" /> {children}
         </DotsButton>
       )
     }, [])
 
-    const Option = useCallback((props) => {
-      return (
-        <div>
-          <components.Option
-            {...props}
-            isDisabled={props.isDisabled}
-            innerProps={{
-              ...props.innerProps,
-              onMouseDown: (e) => {
-                if (shouldDisabledOptions) {
-                  return
-                }
-                if (props.data.shouldStopPropagation) {
-                  e.stopPropagation()
-                  props.data?.onClick()
-                }
-              },
-            }}
-          />
-        </div>
-      )
-    }, [])
+    const Option = useCallback(
+      (props: OptionProps<SelectOption, false>) => {
+        return (
+          <div>
+            <components.Option
+              {...props}
+              innerProps={{
+                ...props.innerProps,
+                onMouseDown: (e) => {
+                  if (shouldDisableOptions) {
+                    return
+                  }
+                  if (props.data.shouldStopPropagation) {
+                    e.stopPropagation()
+                    props.data?.onClick()
+                  }
+                },
+              }}
+            />
+          </div>
+        )
+      },
+      [shouldDisableOptions]
+    )
 
     const colourStyles: StylesConfig<SelectOption, false> = {
       control: (styles, { isDisabled, isFocused }) => {
@@ -266,7 +275,6 @@ export const SelectWithDots: React.ForwardRefExoticComponent<
       dropdownIndicator: (styles) => ({
         ...styles,
         display: 'none',
-        // color: isDisabled ? theme.grey40 : theme.grey70,
       }),
       container: (style) => ({
         ...style,
@@ -315,13 +323,13 @@ export const SelectWithDots: React.ForwardRefExoticComponent<
           closeMenuOnSelect={false}
           onChange={(option) => {
             setOpen(false)
-            onChange(option)
+            onChange && onChange(option)
           }}
           menuIsOpen={open}
           menuPortalTarget={menuPortalTarget}
           styles={colourStyles}
           formatGroupLabel={formatGroupLabel}
-          components={{ ValueContainer, Option, Menu: CustomMenu }}
+          components={{ ValueContainer, Option, Menu: CustomMenu, ...componentsProp }}
           placeholder=""
         />
       </div>

--- a/src/components/SelectWithoutControl/index.tsx
+++ b/src/components/SelectWithoutControl/index.tsx
@@ -1,5 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import ReactSelect, { components, NamedProps, StylesConfig } from 'react-select'
+import ReactSelect, {
+  components,
+  Props,
+  MenuProps,
+  OptionProps,
+  SelectInstance,
+  StylesConfig,
+} from 'react-select'
 import { theme } from '../../theme'
 import { Label } from '../Label'
 import { Button } from '../Button'
@@ -20,11 +27,11 @@ export type SelectOption = {
   onClick?: () => void
 }
 
-export type ReactSelectElement = ReactSelect<SelectOption>
+export type ReactSelectElement = SelectInstance<SelectOption>
 
 export interface SelectWithoutControlProps
   extends Omit<
-    NamedProps<SelectOption>,
+    Props<SelectOption, false>,
     | 'onFocus'
     | 'onBlur'
     | 'isDisabled'
@@ -48,7 +55,7 @@ export interface SelectWithoutControlProps
   onClickRemoveTenant: () => void
   onClickSave: () => void
   onClickCancel: (firstSelectedOption?: SelectOption) => void
-  shouldDisabledOptions?: boolean
+  shouldDisableOptions?: boolean
   removeTenantText?: string
   onBlur?: (firstSelectedOption?: SelectOption) => void
 }
@@ -102,7 +109,7 @@ export const SelectWithoutControl: React.ForwardRefExoticComponent<
       onClickRemoveTenant,
       onClickSave,
       onClickCancel,
-      shouldDisabledOptions,
+      shouldDisableOptions,
       removeTenantText,
       onBlur,
       ...props
@@ -124,7 +131,7 @@ export const SelectWithoutControl: React.ForwardRefExoticComponent<
     }, [defaultValue])
 
     const CustomMenu = useCallback(
-      ({ innerRef, innerProps, children }) => {
+      ({ innerRef, innerProps, children }: MenuProps<SelectOption, false>) => {
         return (
           <div
             ref={innerRef}
@@ -132,7 +139,7 @@ export const SelectWithoutControl: React.ForwardRefExoticComponent<
               zIndex: 20,
               position: 'absolute',
               width: 250,
-              left: -150,
+              right: 0,
               paddingBottom: 0,
             }}
             {...innerProps}
@@ -164,7 +171,7 @@ export const SelectWithoutControl: React.ForwardRefExoticComponent<
               </Button>
               <Button
                 size="sm"
-                disabled={shouldDisabledOptions}
+                disabled={shouldDisableOptions}
                 onClick={() => {
                   onClickSave()
                   setOpen(false)
@@ -179,28 +186,31 @@ export const SelectWithoutControl: React.ForwardRefExoticComponent<
       [onClickRemoveTenant, onClickCancel, onClickSave]
     )
 
-    const Option = useCallback((props) => {
-      return (
-        <div>
-          <components.Option
-            {...props}
-            isDisabled={shouldDisabledOptions}
-            innerProps={{
-              ...props.innerProps,
-              onMouseDown: (e) => {
-                if (shouldDisabledOptions) {
-                  return
-                }
-                if (props.data.shouldStopPropagation) {
-                  e.stopPropagation()
-                  props.data?.onClick()
-                }
-              },
-            }}
-          />
-        </div>
-      )
-    }, [])
+    const Option = useCallback(
+      (props: OptionProps<SelectOption, false>) => {
+        return (
+          <div>
+            <components.Option
+              {...props}
+              isDisabled={shouldDisableOptions}
+              innerProps={{
+                ...props.innerProps,
+                onMouseDown: (e) => {
+                  if (shouldDisableOptions) {
+                    return
+                  }
+                  if (props.data.shouldStopPropagation) {
+                    e.stopPropagation()
+                    props.data?.onClick()
+                  }
+                },
+              }}
+            />
+          </div>
+        )
+      },
+      [shouldDisableOptions]
+    )
 
     const colourStyles: StylesConfig<SelectOption, false> = {
       control: (styles, { isDisabled, isFocused }) => {

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -7,7 +7,9 @@ export default {
   component: Select,
 } as Meta
 
-const Template: Story<SelectProps> = (args) => <Select {...args} />
+const Template: Story<SelectProps> = (args) => (
+  <Select onChange={(option) => console.log(option)} {...args} />
+)
 
 const identityOptions = [
   {
@@ -56,7 +58,6 @@ Primary.args = {
 export const PrimaryGrouped = Template.bind({})
 PrimaryGrouped.args = {
   options: groupedOptions,
-  value: 'option1',
 }
 
 export const PrimaryWithLabel = Template.bind({})

--- a/src/stories/SelectWithDots.stories.tsx
+++ b/src/stories/SelectWithDots.stories.tsx
@@ -106,7 +106,7 @@ PrimaryWithDefaultValueDisabled.args = {
 export const OwnerVariant = Template.bind({})
 OwnerVariant.args = {
   options: identityOptions,
-  shouldDisabledOptions: true,
+  shouldDisableOptions: true,
   label: 'Organization',
   defaultValue: identityOptions.find((option) => option.value === 'MANUAL'),
 }
@@ -114,8 +114,18 @@ OwnerVariant.args = {
 export const OwnerVariantWithMessage = Template.bind({})
 OwnerVariantWithMessage.args = {
   options: identityOptions,
-  shouldDisabledOptions: true,
+  shouldDisableOptions: true,
   removeTenantText: 'Remove myself from tenant',
   label: 'Organization',
   defaultValue: identityOptions.find((option) => option.value === 'MANUAL'),
+}
+
+const CustomValueContainer = ({ children}) => {
+  return <a>Hello, world! {children}</a>
+}
+
+export const PrimaryWithCustomValueContainer = Template.bind({})
+PrimaryWithCustomValueContainer.args = {
+  options: identityOptions,
+  components: { ValueContainer: CustomValueContainer },
 }

--- a/src/stories/SelectWithoutControl.stories.tsx
+++ b/src/stories/SelectWithoutControl.stories.tsx
@@ -7,7 +7,11 @@ export default {
   component: SelectWithoutControl,
 } as Meta
 
-const Template: Story<SelectWithoutControlProps> = (args) => <SelectWithoutControl {...args} />
+const Template: Story<SelectWithoutControlProps> = (args) => (
+  <div style={{ display: 'flex', justifyContent: 'right', margin: 8, width: 250 }}>
+    <SelectWithoutControl {...args} />
+  </div>
+)
 
 const identityOptions = [
   {
@@ -87,7 +91,7 @@ PrimaryWithDefaultValueDisabled.args = {
 export const OwnerVariant = Template.bind({})
 OwnerVariant.args = {
   options: identityOptions,
-  shouldDisabledOptions: true,
+  shouldDisableOptions: true,
   label: 'Organization',
   defaultValue: identityOptions.find((option) => option.value === 'MANUAL'),
 }
@@ -95,25 +99,8 @@ OwnerVariant.args = {
 export const OwnerVariantWithMessage = Template.bind({})
 OwnerVariantWithMessage.args = {
   options: identityOptions,
-  shouldDisabledOptions: true,
+  shouldDisableOptions: true,
   removeTenantText: 'Remove myself from tenant',
   label: 'Organization',
   defaultValue: identityOptions.find((option) => option.value === 'MANUAL'),
 }
-
-// export const PrimaryWithRef = () => {
-//   const ref = useRef(null)
-//   return (
-//     <div>
-//       <PrimaryWithLabel forRef={ref} />
-//       <button
-//         onClick={() => {
-//           console.log(ref?.current)
-//           // ref?.current?.focus()
-//         }}
-//       >
-//         Click to focus
-//       </button>
-//     </div>
-//   )
-// }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1293,10 +1293,21 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
-"@emotion/cache@^11.0.0", "@emotion/cache@^11.1.3":
+"@emotion/cache@^11.1.3":
   version "11.1.3"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.1.3.tgz#c7683a9484bcd38d5562f2b9947873cf66829afd"
   integrity sha512-n4OWinUPJVaP6fXxWZD9OUeQ0lY7DvtmtSuqtRWT0Ofo/sBLCVSgb4/Oa0Q5eFxcwablRKjUXqXtNZVyEwCAuA==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/sheet" "^1.0.0"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    stylis "^4.0.3"
+
+"@emotion/cache@^11.4.0":
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.4.0.tgz#293fc9d9a7a38b9aad8e9337e5014366c3b09ac0"
+  integrity sha512-Zx70bjE7LErRO9OaZrhf22Qye1y4F7iDl+ITjet0J+i+B88PrAOBkKvaAWhxsZf72tDLajwCgfCjJ2dvH77C3g==
   dependencies:
     "@emotion/memoize" "^0.7.4"
     "@emotion/sheet" "^1.0.0"
@@ -2565,23 +2576,6 @@
     "@types/react" "*"
     "@types/reactcss" "*"
 
-"@types/react-dom@*":
-  version "17.0.9"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.9.tgz#441a981da9d7be117042e1a6fd3dac4b30f55add"
-  integrity sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-select@^4.0.18":
-  version "4.0.18"
-  resolved "https://registry.yarnpkg.com/@types/react-select/-/react-select-4.0.18.tgz#f907f406411afa862217a9d86c54a301367a35c1"
-  integrity sha512-uCPRMPshd96BwHuT7oCrFduiv5d6km3VwmtW7rVl9g4XetS3VoJ9nZo540LiwtQgaFcW96POwaxQDZDAyYaepg==
-  dependencies:
-    "@emotion/serialize" "^1.0.0"
-    "@types/react" "*"
-    "@types/react-dom" "*"
-    "@types/react-transition-group" "*"
-
 "@types/react-syntax-highlighter@11.0.4":
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz#d86d17697db62f98046874f62fdb3e53a0bbc4cd"
@@ -2593,13 +2587,6 @@
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@types/react-table/-/react-table-7.7.4.tgz#7d01b3a9516e8dcb7152858271210ef08c6cc32a"
   integrity sha512-CIBJJx9iid8k+kN1/WD8vSXnM1Qc6zX3ihrMnt3ilZxLSrFJSw4wc1u9WeT4dWjbECEO1wJBGVHfSknR4nzFiQ==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-transition-group@*":
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.3.tgz#b0994da0a7023d67dbb4a8910a62112bc00d5688"
-  integrity sha512-fUx5muOWSYP8Bw2BUQ9M9RK9+W1XBK/7FLJ8PTQpnpTEkn0ccyMffyEQvan4C3h53gHdx7KE5Qrxi/LnUGQtdg==
   dependencies:
     "@types/react" "*"
 
@@ -10302,7 +10289,7 @@ prop-types-extra@^1.1.0:
     react-is "^16.3.2"
     warning "^4.0.0"
 
-prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -10638,13 +10625,6 @@ react-infinite-scroll-component@^6.1.0:
   dependencies:
     throttle-debounce "^2.1.0"
 
-react-input-autosize@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-3.0.0.tgz#6b5898c790d4478d69420b55441fcc31d5c50a85"
-  integrity sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==
-  dependencies:
-    prop-types "^15.5.8"
-
 react-inspector@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.0.tgz#45a325e15f33e595be5356ca2d3ceffb7d6b8c3a"
@@ -10742,17 +10722,17 @@ react-router@5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-select@^4.0.2:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-4.1.0.tgz#7ce06b4e8e79b8f58d09a15d25c705abb1ac4885"
-  integrity sha512-OYn+jL8TXMMaZtosErpkdvoI1UWN4ZqMFulIRp5r5bbuqe4OaZN7yv1BNq7PdAJgRu2E19ODFiV1SgJ6wPUaeA==
+react-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.1.0.tgz#ac384c8e25ba6f03126026192b2bdad0f53fbf50"
+  integrity sha512-SkEBD1AYsSXrIdNj5HBt7+Ehe+jxdiB448J0atJqR6lE3l/GcFlRf4JYB3NlHe/02jrW4AnIQLo1t0IqWrxXOw==
   dependencies:
     "@babel/runtime" "^7.12.0"
-    "@emotion/cache" "^11.0.0"
+    "@emotion/cache" "^11.4.0"
     "@emotion/react" "^11.1.1"
+    "@types/react-transition-group" "^4.4.0"
     memoize-one "^5.0.0"
     prop-types "^15.6.0"
-    react-input-autosize "^3.0.0"
     react-transition-group "^4.3.0"
 
 react-sizeme@^2.6.7:


### PR DESCRIPTION
- Ideally, `SelectWithDots` would be a generic Menu component that could attach to any control element, but it's not, so for now we'll allow consumers to pass in a custom control that can replace the dots button.
  - Note: Unfortunately the positioning styles are all relative to the dimensions of the dots button, and there's no generic way to define these styles that doesn't require using JS to dynamically measure the size of the control element like what Menu components typically do, so the consumer will have to manually override the positioning relative to the control they pass in 🤢.
- Allow overriding styles via prop
- The version of `react-select` we were using no longer has its types maintained, so I just upgraded the package. Even though everything seems to behave the same, I bumped the major version just in case.
- Since this is a major version bump anyway, renamed some props to be more grammatically correct
- Also fixed a bug in `SelectWithControl` that assumed that the input would be a certain width