### PR TITLE
Support group header labels for Select options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aserto/aserto-react-components",
-  "version": "7.5.2",
+  "version": "7.6.0",
   "description": "Aserto React components",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -97,7 +97,7 @@ export const Select: React.ForwardRefExoticComponent<
             ? theme.grey20
             : theme.grey20,
           borderLeft: isSelected ? `5px solid ${theme.lochivarAccent3}` : '',
-          color: isFocused ? theme.grey100 : theme.grey70,
+          color: theme.grey100,
           height: 36,
           fontSize: 14,
           lineHeight: '20px',
@@ -123,7 +123,7 @@ export const Select: React.ForwardRefExoticComponent<
             alignItems: 'center',
             margin: 0,
             height: 36,
-            backgroundColor: theme.grey40,
+            backgroundColor: theme.lochivar60,
             color: theme.grey100,
             fontSize: 14,
             fontWeight: 'bold'

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -97,7 +97,7 @@ export const Select: React.ForwardRefExoticComponent<
             ? theme.grey20
             : theme.grey20,
           borderLeft: isSelected ? `5px solid ${theme.lochivarAccent3}` : '',
-          color: theme.grey100,
+          color: isFocused ? theme.grey100 : theme.grey70,
           height: 36,
           fontSize: 14,
           lineHeight: '20px',

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -35,17 +35,7 @@ export interface SelectProps
   disableLabel?: boolean
 }
 
-const groupLabelStyle = {
-  position: 'relative' as const,
-  marginTop: -8,
-  marginBottom: -3,
-  marginLeft: -11,
-  marginRight: -11,
-  height: 1,
-  backgroundColor: theme.grey,
-}
-
-const formatGroupLabel = () => <div style={groupLabelStyle} />
+const formatGroupLabel = (group: GroupBase<SelectOption>) => <div>{group.label}</div>
 
 export const Select: React.ForwardRefExoticComponent<
   SelectProps & React.RefAttributes<ReactSelectElement>
@@ -118,10 +108,32 @@ export const Select: React.ForwardRefExoticComponent<
           },
         }
       },
+      groupHeading: (styles, props) => {
+        if (!props.data.label) {
+          return {
+            ...styles,
+            height: 1,
+            backgroundColor: theme.grey,
+            margin: 0,
+          }
+        } else {
+          return {
+            ...styles,
+            display: 'flex',
+            alignItems: 'center',
+            margin: 0,
+            height: 36,
+            backgroundColor: theme.lochivar60,
+            color: theme.grey100,
+            fontSize: 14,
+            fontWeight: 'normal'
+          }
+        }
+      },
       group: (styles) => {
         return {
           ...styles,
-          paddingBottom: 0,
+          padding: 0,
         }
       },
       input: (styles) => {
@@ -164,6 +176,10 @@ export const Select: React.ForwardRefExoticComponent<
         ...styles,
         fontSize: 14,
       }),
+      noOptionsMessage: (styles) => ({
+        ...styles,
+        backgroundColor: theme.grey20,
+      })
     }
     return (
       <div style={style}>

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -123,10 +123,10 @@ export const Select: React.ForwardRefExoticComponent<
             alignItems: 'center',
             margin: 0,
             height: 36,
-            backgroundColor: theme.lochivar60,
+            backgroundColor: theme.grey40,
             color: theme.grey100,
             fontSize: 14,
-            fontWeight: 'normal'
+            fontWeight: 'bold'
           }
         }
       },

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -37,10 +37,11 @@ const groupedOptions = [
     ],
   },
   {
+    label: 'This is a label',
     options: [
       {
-        label: "I'm another group!",
-        value: 'another_group',
+        label: "I'm a labeled group!",
+        value: 'labeled_group',
       },
     ],
   },


### PR DESCRIPTION
<img width="544" alt="Screen Shot 2022-01-11 at 10 30 58 PM" src="https://user-images.githubusercontent.com/88290408/149059040-fa201a2d-484d-4dbf-80a6-8c423c7c3c9e.png">
