### PR TITLE
Fix height of options that are bigger than the width of the select

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aserto/aserto-react-components",
-  "version": "7.7.0",
+  "version": "7.7.1",
   "description": "Aserto React components",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -71,6 +71,7 @@ export const Select: React.ForwardRefExoticComponent<
         return {
           ...styles,
           minHeight: 36,
+          height: '100%',
           backgroundColor: isDisabled ? theme.grey20 : theme.primaryBlack,
           color: isDisabled ? theme.grey40 : theme.grey100,
           borderColor: isFocused ? theme.lochivarAccent2 : theme.grey40,
@@ -98,7 +99,8 @@ export const Select: React.ForwardRefExoticComponent<
             : theme.grey20,
           borderLeft: isSelected ? `5px solid ${theme.lochivarAccent3}` : '',
           color: isFocused ? theme.grey100 : theme.grey70,
-          height: 36,
+          height: '100%',
+          minHeight: 36,
           fontSize: 14,
           lineHeight: '20px',
           cursor: isDisabled ? 'not-allowed' : 'default',
@@ -122,11 +124,12 @@ export const Select: React.ForwardRefExoticComponent<
             display: 'flex',
             alignItems: 'center',
             margin: 0,
-            height: 36,
+            minHeight: 36,
+            height: '100%',
             backgroundColor: theme.lochivar60,
             color: theme.grey100,
             fontSize: 14,
-            fontWeight: 'bold'
+            fontWeight: 'bold',
           }
         }
       },
@@ -179,7 +182,7 @@ export const Select: React.ForwardRefExoticComponent<
       noOptionsMessage: (styles) => ({
         ...styles,
         backgroundColor: theme.grey20,
-      })
+      }),
     }
     return (
       <div style={style}>

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -43,6 +43,11 @@ const groupedOptions = [
         label: "I'm a labeled group!",
         value: 'labeled_group',
       },
+      {
+        label:
+          "I'm a labeled group with a big size! This should be enought to have more than one line in small screens. If you are not seeing more than one line, please reduce the width of your browser",
+        value: 'labeled_group',
+      },
     ],
   },
   {


### PR DESCRIPTION
Fix the error when an option text is bigger to fit one line.

Test plan: Execute storybook locally and type this URL on browser:

http://localhost:6006/?path=/story/common-select--primary-grouped